### PR TITLE
Fix: Add flagembedding dependency to resolve Module FlagEmbedding not found error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "langchain-oceanbase>=0.3.2",
     "python-dotenv>=1.0.1",
     "powermem>=0.4.0",
+    "flagembedding>=1.2.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Description

This PR fixes issue #29 by adding the missing `flagembedding` dependency to `pyproject.toml`.

## Problem

The application fails when initializing BGE embedding because the `FlagEmbedding` module is not found. The error occurs in `src/rag/embedding/bge.py` when trying to import `BGEM3FlagModel` from `FlagEmbedding`.

## Solution

Added `flagembedding>=1.2.0` to the project dependencies in `pyproject.toml`.

## Related Issue

Closes #29